### PR TITLE
Update Easing Curves.md

### DIFF
--- a/_posts/_drafts/Easing Curves.md
+++ b/_posts/_drafts/Easing Curves.md
@@ -1,12 +1,12 @@
 # Crafting Easing Curves for UI
 
-Easing curves are what makes decent animations and make them FANTASTIC! The problem is that understanding how easing curves work can be a bit confusing, I hope to clear that up through this post. This article stems from the interest in timing functions my previous post After Effects to CSS. People wanted a better understanding about how easing curves work and how do design your own.
+Easing curves are what takes decent animations and make them FANTASTIC! The problem is that understanding how easing curves work can be a bit confusing. I hope to clear that up through this post, which stems from the interest in timing functions my previous post [After Effects to CSS](LINK TO POST). People wanted a better understanding about how easing curves work and how do design your own.
 
 An easing curve is a line that defines the acceleration pattern on a graph. Easing curves are commonly referred by many other names such as “Motion Curves”, “Timing Functions”, “Bezier Curves” or just “Curves”. The different shapes of an easing curves also has keywords like “ease in” , “ease out”, or “ease in out”.
 
 ## How Easing Curves Work
 
- Easing curves are created with an XY axis. The meanings of the X and the Y can vary from application to application. For example, the XY meaning within After Effects is different than Cinema 4D. Within development, the meaning of the X and the Y states stays pretty consistent. Which is defined as Percent of Animation(Y) over Time(X).
+Easing curves are created via an (X,Y) axis. The meanings of the X and the Y can vary from application to application. For example, the (X,Y) meaning within After Effects is different than Cinema 4D. Within development, the meaning of the X and the Y states stays pretty consistent. Which is defined as Percent of Animation(Y) over Time(X).
 
 [Image]
 
@@ -26,12 +26,12 @@ Timing and Spacing Timing is the duration for an animation to finish. Spacing is
 
 Easing curves within development are called “Timing Functions” which are mathematical equations that create a bezier curve that defines the acceleration pattern on a graph. The function that is commonly used within development is the cubic-bezier. That is what I will be going over in this post.
 
-The structure of a cubic-bezier
+The structure of a cubic-bezier:
 
 [Image]
 `cubic-bezier(x1, x2, y1, y2)`
 
-Within most programming languages, there are some predefined easing curves like easeIn, easeOut, and easeInOut. Be sure to check the documentation to see which curves are predefined. Below I listed the easing curves that are predefined within CSS.
+Within most programming languages, there are some predefined easing curves like `easeIn`, `easeOut`, and `easeInOut`. Be sure to check the documentation to see which curves are predefined. Below I listed the easing curves that are predefined within CSS.
 
 `easeIn` = `cubic-bezier(x1, x2, y1, y2)`
 
@@ -52,7 +52,7 @@ In CSS there is the “global” ease that can be defined in the object class, t
 
 **Per Keyframe**
 
-You can get more precise with eases by defining them within keyframes. It is important to keep in mind that the easing curve is defined in the percentage value BEFORE you want the ease to happen.
+You can get more precise with eases by defining them within keyframes. It is important to keep in mind that the easing curve is defined in the percentage value *before* you want the ease to happen.
 
 [Insert codepen example]
 
@@ -80,7 +80,7 @@ You can get more precise with eases by defining them within keyframes. It is imp
 
 Designing an Easing Curve People always ask me, “What easing curve do I use and when?” My answer — it really depends on the scenario. There is not one easing curve that work for absolutely everything. This is a key component of designing motion — crafting these curves. Easing curves are commonly designed after physics within the real world, but don’t always follow those rules. The real world is a great place to gain inspiration for animation. For example, no object in the real world starts at full velocity and immediately stops — like a linear easing curve does. Objects always have some kind of acceleration or decelation. This is just one of the concepts Disney has outlined in the [12 principles of animation](https://vimeo.com/93206523), which is largely based on physics.
 
-When crafting an easing curve keep in mind that vertical is fast and horizontal is slow. The curve you create should be dependent on the interaction. You can create many different types of curves within the XY grid.
+When crafting an easing curve keep in mind that vertical is fast and horizontal is slow. The curve you create should be dependent on the interaction. You can create many different types of curves within the (X,Y) grid.
 
 [Insert Sine ,etc ]
 


### PR DESCRIPTION
:) just FYI, when you capitalize text like BEFORE, a screen reader thinks it is an acronym and reads it as B-E-F-O-R-E (I use screen readers to listen to blog posts, remember?)
